### PR TITLE
Decomposition tweak for robustness/safety

### DIFF
--- a/qbittensor/validator/peaked_circuit_creation/lib/decompose/__init__.py
+++ b/qbittensor/validator/peaked_circuit_creation/lib/decompose/__init__.py
@@ -15,6 +15,7 @@ def optim_decomp(
     U_target: np.ndarray[complex, 2],
     fidelity: ObjectiveFn,
     epsilon: Optional[float] = 1e-6,
+    max_tries: int = 1000,
 ) -> np.ndarray[float, 1]:
     """
     Compute a decomposition of `U_target` using `scipy.optimize`, given an
@@ -30,24 +31,37 @@ def optim_decomp(
             optimim.
         epsilon (Optional[float]):
             Tolerance value for optimization.
+        max_tries (int):
+            Maximum number of calls to scipy for decomposition before failing
+            with `RuntimeError`.
 
     Returns:
         params (numpy.ndarray[float, 1]):
             1D array of final parameter values for the decomposition.
+
+    Raises:
+        RuntimeError:
+            - scipy.optimize fails to satisfy error tolerance `epsilon` more
+              than `max_tries` times.
     """
     # use a completely fixed generator here to keep decompositions consistent
     # without affecting global state, and without requiring a `seed` parameter
     gen = np.random.Generator(np.random.PCG64(10546))
-    params0 = max(
-        (2 * np.pi * np.random.random(size=15) for _ in range(2000)),
-        key=lambda params: fidelity(U_target, params)
-    )
-    optim_res = minimize(
-        lambda params, targ: -fidelity(targ, params),
-        params0,
-        args=(U_target,),
-        tol=epsilon,
-        options=dict(maxiter=10000)
-    )
-    return optim_res.x
+    # scipy.optimize will somtimes get stuck in local minima; just sticking this
+    # in a loop should be fine (really shouldn't need more than 2-3 iters in
+    # 99.99% of cases)
+    for _ in range(max_tries):
+        params0 = 2 * np.pi * np.random.random(size=15)
+        optim = minimize(
+            lambda params, targ: -fidelity(targ, params),
+            params0,
+            args=(U_target,),
+            tol=epsilon,
+            options=dict(maxiter=10000),
+        )
+        final_fidelity = fidelity(U_target, params)
+        if optim.success and abs(final_fidelity - 1) < epsilon:
+            return optim.x
+    raise RuntimeError(
+        f"optim_decomp: got stuck in local minima >{max_tries} times")
 


### PR DESCRIPTION
Although solutions to gate decompositions are guaranteed, scipy can rarely get stuck in local minima; here modify `optim_decomp` to have the optim happen in a loop that randomizes the initial condition on each iter. This loop shouldn't run more than 2-3 times for 99.99% of cases.

This should be run through the normal testing procedure.